### PR TITLE
Adds PHP 5 & CSRF Protection compatibility 

### DIFF
--- a/batch/tasks/BatchTask.php
+++ b/batch/tasks/BatchTask.php
@@ -184,7 +184,7 @@ class BatchTask extends BaseTask
       $criteria->status = $status == 'null' ? null : $status;
     }
 
-    $criteria->offset = $offset ?? 0;
+    $criteria->offset = isset($offset) ? $offset : 0;
 
     $criteria->limit = null;
     $criteria->find();

--- a/batch/templates/settings/index.twig
+++ b/batch/templates/settings/index.twig
@@ -26,6 +26,7 @@
   {% endif %}
     
   <form class="" method="post" accept-charset="UTF-8">
+    {{ getCsrfInput() }}
     <input type="hidden" name="action" value="batch">
     <input type="hidden" name="pluginClass" value="Batch">
     <input type="hidden" name="redirect" value="settings/plugins/batch/settings">


### PR DESCRIPTION
Fixes the plugin form for Craft installs that have [`enableCsrfProtection` config value](https://craftcms.com/docs/config-settings#enableCsrfProtection) set to `true`. Also adds support for older versions of PHP.